### PR TITLE
fix(listforge): ignore adblock detection alert on minecraftpocket-servers.com

### DIFF
--- a/scripts/listforge.net.js
+++ b/scripts/listforge.net.js
@@ -38,7 +38,8 @@ async function vote(first) {
 
         if (request.message.includes('need to accept our Privacy Policy')
             || request.message.includes('website is made possible by displaying online advertisements')
-            || request.message.includes('have one unread message')) continue
+            || request.message.includes('have one unread message')
+            || request.message.includes('Ad blocker detected')) continue
 
         if (request.message.includes('already voted') || request.message.includes('have reached your daily vote limit')) {
             chrome.runtime.sendMessage({later: true})


### PR DESCRIPTION
On `minecraftpocket-servers.com`, the site's adblock detector fires even when no ad blocker is present, likely because the extension's context trips the bait-element check. The vote script already hides the relevant DOM elements (`blocked-notice`, `vote-loading-block`, `vote-form-block`) at the top of `vote()`, but the "Ad blocker detected" alert was still being picked up by the `div.alert.alert-danger` loop and reported as an error, causing the vote to abort.

Fix: add `Ad blocker detected` to the ignore list in that loop so the script continues to vote submission instead of bailing out early.